### PR TITLE
Downgraded target JDK to 11

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 group = "io.github.gmazzo.test.aggregation"
 description = "Test Aggregation Plugin for Android"
 
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+
 gitVersioning.apply {
     refs {
         branch(".+") {


### PR DESCRIPTION
Sets the minimum JDK to 11, fixes #6 