### PR TITLE
Fix aggregation issues

### DIFF
--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
@@ -174,10 +174,6 @@ abstract class AndroidTestCoverageAggregationPlugin : Plugin<Project> {
                 .toGet(ScopedArtifact.CLASSES, { allVariantsJars }, { allVariantsDirs })
         }
 
-        dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE)
-            .compatibilityRules
-            .add(UsageTestAggregationCompatibilityRule::class.java)
-
         configurations.create("codeCoverageElements") {
             isCanBeConsumed = true
             isCanBeResolved = false

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
@@ -4,7 +4,6 @@ import com.android.build.api.artifact.ScopedArtifact
 import com.android.build.api.variant.ScopedArtifacts
 import com.android.build.api.variant.UnitTest
 import com.android.build.api.variant.Variant
-import io.github.gmazzo.android.test.aggregation.UsageTestAggregationCompatibilityRule.Companion.USAGE_TEST_AGGREGATION
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
@@ -20,6 +19,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Sync
 import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.kotlin.dsl.USAGE_TEST_AGGREGATION
 import org.gradle.kotlin.dsl.aggregateTestCoverage
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestCoverageAggregationPlugin.kt
@@ -27,8 +27,10 @@ class TestCoverageAggregationPlugin : Plugin<Project> {
         val jacocoAggregation by configurations
 
         allprojects {
-            plugins.withId("jacoco") {
-                jacocoAggregation.dependencies.add(dependencies.testAggregation(project))
+            plugins.withId("java") {
+                plugins.withId("jacoco") {
+                    jacocoAggregation.dependencies.add(dependencies.testAggregation(project))
+                }
             }
 
             plugins.withId("com.android.base") {

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestResultsAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestResultsAggregationPlugin.kt
@@ -29,7 +29,7 @@ class TestResultsAggregationPlugin : Plugin<Project> {
         allprojects {
 
             plugins.withId("jvm-test-suite") {
-                testReportAggregation.dependencies.add(dependencies.testAggregation(project))
+                //testReportAggregation.dependencies.add(dependencies.testAggregation(project))
             }
 
             plugins.withId("com.android.base") {

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestResultsAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestResultsAggregationPlugin.kt
@@ -29,7 +29,7 @@ class TestResultsAggregationPlugin : Plugin<Project> {
         allprojects {
 
             plugins.withId("jvm-test-suite") {
-                //testReportAggregation.dependencies.add(dependencies.testAggregation(project))
+                testReportAggregation.dependencies.add(dependencies.testAggregation(project))
             }
 
             plugins.withId("com.android.base") {

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/UsageTestAggregationCompatibilityRule.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/UsageTestAggregationCompatibilityRule.kt
@@ -1,9 +1,12 @@
 package io.github.gmazzo.android.test.aggregation
 
+import org.gradle.api.Project
 import org.gradle.api.attributes.AttributeCompatibilityRule
+import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.Usage
 import org.gradle.kotlin.dsl.USAGE_TEST_AGGREGATION
+import org.gradle.kotlin.dsl.add
 
 internal class UsageTestAggregationCompatibilityRule : AttributeCompatibilityRule<Usage> {
 
@@ -11,6 +14,21 @@ internal class UsageTestAggregationCompatibilityRule : AttributeCompatibilityRul
         if (consumerValue?.name == USAGE_TEST_AGGREGATION && producerValue?.name == Usage.JAVA_RUNTIME) {
             compatible()
         }
+    }
+
+    companion object {
+
+        fun bind(project: Project) {
+            bind(project.dependencies.attributesSchema)
+        }
+
+        fun bind(schema: AttributesSchema) {
+            schema
+                .attribute(Usage.USAGE_ATTRIBUTE)
+                .compatibilityRules
+                .add(UsageTestAggregationCompatibilityRule::class)
+        }
+
     }
 
 }

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/UsageTestAggregationCompatibilityRule.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/UsageTestAggregationCompatibilityRule.kt
@@ -3,12 +3,9 @@ package io.github.gmazzo.android.test.aggregation
 import org.gradle.api.attributes.AttributeCompatibilityRule
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.Usage
+import org.gradle.kotlin.dsl.USAGE_TEST_AGGREGATION
 
 internal class UsageTestAggregationCompatibilityRule : AttributeCompatibilityRule<Usage> {
-
-    companion object {
-        const val USAGE_TEST_AGGREGATION = "test-aggregation"
-    }
 
     override fun execute(details: CompatibilityCheckDetails<Usage>) = with(details) {
         if (consumerValue?.name == USAGE_TEST_AGGREGATION && producerValue?.name == Usage.JAVA_RUNTIME) {

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/TestAggregationDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/TestAggregationDSL.kt
@@ -2,6 +2,7 @@ package org.gradle.kotlin.dsl
 
 import com.android.build.api.dsl.BuildType
 import com.android.build.api.dsl.ProductFlavor
+import io.github.gmazzo.android.test.aggregation.UsageTestAggregationCompatibilityRule
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
@@ -12,6 +13,8 @@ const val USAGE_TEST_AGGREGATION = "test-aggregation"
 
 fun DependencyHandler.testAggregation(dependency: Any): Dependency = create(dependency).also {
     (it as? ProjectDependency)?.apply {
+        UsageTestAggregationCompatibilityRule.bind(dependencyProject)
+
         attributes {
             attribute(Usage.USAGE_ATTRIBUTE, dependencyProject.objects.named(USAGE_TEST_AGGREGATION))
         }

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/TestAggregationDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/TestAggregationDSL.kt
@@ -2,20 +2,19 @@ package org.gradle.kotlin.dsl
 
 import com.android.build.api.dsl.BuildType
 import com.android.build.api.dsl.ProductFlavor
-import io.github.gmazzo.android.test.aggregation.UsageTestAggregationCompatibilityRule
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.attributes.Usage
 import org.gradle.api.provider.Property
 
-fun DependencyHandler.testAggregation(project: Project): Dependency = create(project).apply {
-    (this as? ModuleDependency)?.attributes {
-        attribute(
-            Usage.USAGE_ATTRIBUTE,
-            project.objects.named(UsageTestAggregationCompatibilityRule.USAGE_TEST_AGGREGATION)
-        )
+const val USAGE_TEST_AGGREGATION = "test-aggregation"
+
+fun DependencyHandler.testAggregation(dependency: Any): Dependency = create(dependency).also {
+    (it as? ProjectDependency)?.apply {
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, dependencyProject.objects.named(USAGE_TEST_AGGREGATION))
+        }
     }
 }
 

--- a/plugin/src/main/resources/META-INF/gradle-plugins/android-test-coverage-aggregation-support.properties
+++ b/plugin/src/main/resources/META-INF/gradle-plugins/android-test-coverage-aggregation-support.properties
@@ -1,0 +1,1 @@
+implementation-class=io.github.gmazzo.android.test.aggregation.AndroidTestCoverageAggregationPlugin

--- a/plugin/src/main/resources/META-INF/gradle-plugins/android-test-results-aggregation-support.properties
+++ b/plugin/src/main/resources/META-INF/gradle-plugins/android-test-results-aggregation-support.properties
@@ -1,0 +1,1 @@
+implementation-class=io.github.gmazzo.android.test.aggregation.AndroidTestResultsAggregationPlugin


### PR DESCRIPTION
Fixes https://github.com/gmazzo/gradle-android-test-aggregation-plugin/issues/8 by only aggregating JVM modules that apply both `java` and `jacoco` plguins.