### PR TITLE
Fixed incompatibility with `android.testFixtures.enable = true`

### DIFF
--- a/demo-project/login/build.gradle.kts
+++ b/demo-project/login/build.gradle.kts
@@ -7,6 +7,7 @@ android {
     namespace = "com.example.login"
     compileSdk = libs.versions.android.sdk.get().toInt()
     buildFeatures.viewBinding = true
+    testFixtures.enable = true
 
     defaultConfig {
         minSdk = 21

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
@@ -95,6 +95,7 @@ abstract class AndroidTestCoverageAggregationPlugin : Plugin<Project> {
             isCanBeResolved = false
             isVisible = false
             attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(USAGE_TEST_AGGREGATION))
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
                 attribute(
                     TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,
@@ -129,6 +130,7 @@ abstract class AndroidTestCoverageAggregationPlugin : Plugin<Project> {
             isCanBeResolved = false
             isVisible = false
             attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(USAGE_TEST_AGGREGATION))
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
                 attribute(
                     TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestResultsAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestResultsAggregationPlugin.kt
@@ -5,9 +5,11 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.TestSuiteType
+import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.VerificationType
 import org.gradle.api.tasks.testing.Test
 import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.kotlin.dsl.USAGE_TEST_AGGREGATION
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.named
 
@@ -21,6 +23,7 @@ abstract class AndroidTestResultsAggregationPlugin : Plugin<Project> {
             isCanBeResolved = false
             isVisible = false
             attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(USAGE_TEST_AGGREGATION))
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
                 attribute(
                     TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,


### PR DESCRIPTION
Fixes #51 incompatibility when using with `android.testFixtures.enable = true`.