### PR TITLE
Fixed `finalizeDSL` block preventing property changes

### DIFF
--- a/demo-project/app/build.gradle.kts
+++ b/demo-project/app/build.gradle.kts
@@ -3,14 +3,16 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+
 android {
     namespace = "com.example.myapplication"
-    compileSdk = libs.versions.android.sdk.get().toInt()
     buildFeatures.viewBinding = true
 
+    compileSdk = libs.versions.android.compileSDK.get().toInt()
     defaultConfig {
-        applicationId = "com.example.myapplication"
-        minSdk = 21
+        minSdk = libs.versions.android.minSDK.get().toInt()
+
         versionCode = 1
         versionName = "1.0"
 

--- a/demo-project/domain/build.gradle.kts
+++ b/demo-project/domain/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     jacoco
 }
 
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+
 dependencies {
     testImplementation(libs.junit)
 }

--- a/demo-project/login/build.gradle.kts
+++ b/demo-project/login/build.gradle.kts
@@ -3,14 +3,16 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+
 android {
     namespace = "com.example.login"
-    compileSdk = libs.versions.android.sdk.get().toInt()
     buildFeatures.viewBinding = true
     testFixtures.enable = true
 
+    compileSdk = libs.versions.android.compileSDK.get().toInt()
     defaultConfig {
-        minSdk = 21
+        minSdk = libs.versions.android.minSDK.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/demo-project/ui-tests/build.gradle.kts
+++ b/demo-project/ui-tests/build.gradle.kts
@@ -3,9 +3,15 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+
 android {
     namespace = "com.example.app.test"
-    compileSdk = libs.versions.android.sdk.get().toInt()
+
+    compileSdk = libs.versions.android.compileSDK.get().toInt()
+    defaultConfig {
+        minSdk = libs.versions.android.minSDK.get().toInt()
+    }
 
     targetProjectPath = projects.demoProject.app.dependencyProject.path
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,8 @@
 [versions]
 kotlin = "1.9.10"
 agp = "8.1.2"
-android-sdk = "34"
+android-minSDK = "21"
+android-compileSDK = "34"
 androidx-lifecycle = "2.6.2"
 androidx-navigation = "2.7.4"
 

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestBaseAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestBaseAggregationPlugin.kt
@@ -2,9 +2,9 @@
 
 package io.github.gmazzo.android.test.aggregation
 
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.aggregateTestCoverage
 import org.gradle.kotlin.dsl.apply
@@ -13,7 +13,7 @@ import org.gradle.kotlin.dsl.typeOf
 
 internal abstract class AndroidTestBaseAggregationPlugin : Plugin<Project> {
 
-    internal abstract val extendedProperties: ListProperty<Property<*>>
+    abstract val extendedProperties: DomainObjectSet<Property<*>>
 
     override fun apply(target: Project): Unit = with(target) {
         apply(plugin = "com.android.base")
@@ -34,8 +34,7 @@ internal abstract class AndroidTestBaseAggregationPlugin : Plugin<Project> {
         }
 
         androidComponents.finalizeDsl {
-            extendedProperties.finalizeValue()
-            extendedProperties.get().forEach { it.finalizeValue() }
+            extendedProperties.all { finalizeValue() }
         }
     }
 


### PR DESCRIPTION
Fixes #69 by replacing the logic with an `all` closure, preventing modification of further added extensions