### PR TITLE
Added `jacocoAggregatedCoverageVerification` verification task for enforcing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ run to produce the report. All dependent `test` tasks will be run too to produce
 The same for `:testAggregatedReport`:
 ![Aggregated Test Report example](README-aggregated-test-report.png)
 
+## Enforcing aggregated code coverage metrics
+The same as `JaCoCo Plugin` supports [Enforcing code coverage metrics](https://docs.gradle.org/current/userguide/jacoco_plugin.html#ex-configuring-violation-rules)
+this plugin adds a ':jacocoAggregatedCoverageVerification' to provide the same feature, but with the aggregated metrics:
+```kotlin
+tasks.jacocoAggregatedCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.5".toBigDecimal()
+            }
+        }
+
+        rule {
+            isEnabled = false
+            element = "CLASS"
+            includes = listOf("org.gradle.*")
+
+            limit {
+                counter = "LINE"
+                value = "TOTALCOUNT"
+                maximum = "0.3".toBigDecimal()
+            }
+        }
+    }
+}
+```
+
 ## The `aggregateTestCoverage` DSL extension
 This is an opt-in/out switch meant to be used when having `productFlavors`.
 

--- a/demo-project/build.gradle.kts
+++ b/demo-project/build.gradle.kts
@@ -13,3 +13,21 @@ testAggregation {
         exclude("**/ContentMainBinding*")
     }
 }
+
+tasks.jacocoAggregatedCoverageVerification {
+    violationRules {
+        rule {
+            limit {// current 19%
+                minimum = "0.19".toBigDecimal()
+            }
+            limit {// desired 80%
+                minimum = "0.8".toBigDecimal()
+                isFailOnViolation = false
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoAggregatedCoverageVerification)
+}

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestCoverageAggregationPlugin.kt
@@ -11,9 +11,11 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getValue
 import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.the
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.testing.jacoco.plugins.JacocoCoverageReport
+import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 
 class TestCoverageAggregationPlugin : Plugin<Project> {
 
@@ -37,6 +39,16 @@ class TestCoverageAggregationPlugin : Plugin<Project> {
                     )
                 }
             }
+
+        tasks.register<JacocoCoverageVerification>("jacocoAggregatedCoverageVerification") {
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
+            description = "Verifies code coverage metrics for the aggregated report"
+
+            val reportTask = provider { jacocoReport.reportTask.get() } // breaks dependency
+            executionData(reportTask.map { it.executionData })
+            classDirectories.from(reportTask.map { it.classDirectories })
+            sourceDirectories.from(reportTask.map { it.sourceDirectories })
+        }
 
         val jacocoAggregation by configurations
 


### PR DESCRIPTION
Address #72 and #63 by introducing a `jacocoAggregatedCoverageVerification` to allow enforcing aggregated metrics by introducing violation rules from `JaCoCo plugin`

Same behavior than [Enforcing code coverage metrics](https://docs.gradle.org/current/userguide/jacoco_plugin.html#ex-configuring-violation-rules)
