### PR TITLE
Allow to set `aggregateTestCoverage` from root project

### DIFF
--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestBaseAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestBaseAggregationPlugin.kt
@@ -2,7 +2,6 @@
 
 package io.github.gmazzo.android.test.aggregation
 
-import org.gradle.api.DomainObjectSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -13,8 +12,6 @@ import org.gradle.kotlin.dsl.typeOf
 
 internal abstract class AndroidTestBaseAggregationPlugin : Plugin<Project> {
 
-    abstract val extendedProperties: DomainObjectSet<Property<*>>
-
     override fun apply(target: Project): Unit = with(target) {
         apply(plugin = "com.android.base")
 
@@ -22,19 +19,15 @@ internal abstract class AndroidTestBaseAggregationPlugin : Plugin<Project> {
             extensions.add(
                 typeOf<Property<Boolean>>(),
                 ::aggregateTestCoverage.name,
-                objects.property<Boolean>().also(extendedProperties::add)
+                objects.property<Boolean>()
             )
         }
         android.productFlavors.configureEach {
             extensions.add(
                 typeOf<Property<Boolean>>(),
                 ::aggregateTestCoverage.name,
-                objects.property<Boolean>().also(extendedProperties::add)
+                objects.property<Boolean>()
             )
-        }
-
-        androidComponents.finalizeDsl {
-            extendedProperties.all { finalizeValue() }
         }
     }
 

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestResultsAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestResultsAggregationPlugin.kt
@@ -35,13 +35,11 @@ abstract class AndroidTestResultsAggregationPlugin : Plugin<Project> {
         }
 
         androidComponents.onVariants { variant ->
-            if ((variant as? HasUnitTest)?.unitTest != null && android.shouldAggregate(variant)) {
-                afterEvaluate {
-                    val testTask = unitTestTaskOf(variant)!!
+            testResultsElements.outgoing.artifacts(provider {
+                val aggregate = (variant as? HasUnitTest)?.unitTest != null && android.shouldAggregate(variant)
 
-                    testResultsElements.outgoing.artifact(testTask.flatMap { it.binaryResultsDirectory })
-                }
-            }
+                if (aggregate) listOf(unitTestTaskOf(variant)!!.flatMap { it.binaryResultsDirectory }) else emptyList()
+            })
         }
     }
 


### PR DESCRIPTION
Fixes #144, were `aggregateTestCoverage` was early finalized, prevent to setting it from a root's `allprojects` closure