### PR TITLE
Addressed `Gradle 8.13` breaking changes

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionSha256Sum=20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestCoverageAggregationPlugin.kt
@@ -12,13 +12,14 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.attributes.TestSuiteType
+import org.gradle.api.attributes.TestSuiteName
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.VerificationType
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.AbstractTestTask
@@ -67,8 +68,8 @@ abstract class AndroidTestCoverageAggregationPlugin : Plugin<Project> {
                 attribute(Usage.USAGE_ATTRIBUTE, objects.named(USAGE_TEST_AGGREGATION))
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
                 attribute(
-                    TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,
-                    objects.named(TestSuiteType.UNIT_TEST)
+                    TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE,
+                    objects.named(SourceSet.TEST_SOURCE_SET_NAME)
                 )
                 attribute(
                     VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
@@ -100,8 +101,8 @@ abstract class AndroidTestCoverageAggregationPlugin : Plugin<Project> {
                 attribute(Usage.USAGE_ATTRIBUTE, objects.named(USAGE_TEST_AGGREGATION))
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
                 attribute(
-                    TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,
-                    objects.named(TestSuiteType.UNIT_TEST)
+                    TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE,
+                    objects.named(SourceSet.TEST_SOURCE_SET_NAME)
                 )
                 attribute(
                     VerificationType.VERIFICATION_TYPE_ATTRIBUTE,

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestResultsAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/AndroidTestResultsAggregationPlugin.kt
@@ -4,9 +4,10 @@ import com.android.build.api.variant.HasUnitTest
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.TestSuiteType
+import org.gradle.api.attributes.TestSuiteName
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.VerificationType
+import org.gradle.api.tasks.SourceSet
 import org.gradle.kotlin.dsl.USAGE_TEST_AGGREGATION
 import org.gradle.kotlin.dsl.aggregateTestCoverage
 import org.gradle.kotlin.dsl.apply
@@ -25,8 +26,8 @@ abstract class AndroidTestResultsAggregationPlugin : Plugin<Project> {
                 attribute(Usage.USAGE_ATTRIBUTE, objects.named(USAGE_TEST_AGGREGATION))
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
                 attribute(
-                    TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,
-                    objects.named(TestSuiteType.UNIT_TEST)
+                    TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE,
+                    objects.named(SourceSet.TEST_SOURCE_SET_NAME)
                 )
                 attribute(
                     VerificationType.VERIFICATION_TYPE_ATTRIBUTE,

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/InternalDSL.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/InternalDSL.kt
@@ -16,6 +16,7 @@ import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.testAggregation
 import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
+import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinTargetsContainer
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
@@ -32,6 +33,12 @@ internal val Project.testAggregationExtension: TestAggregationExtension
             modules.includes.finalizeValueOnRead()
             modules.excludes.finalizeValueOnRead()
         }
+
+internal fun Project.ensureMinGradleVersion() {
+    if (GradleVersion.current() < GradleVersion.version("8.13")) {
+        error("This plugin requires Gradle 8.13 or later")
+    }
+}
 
 internal fun Project.ensureItsNotJava() = plugins.withId("java-base") {
     error("This plugin can not work with `java` plugin as well. It's recommended to apply it at the root project with at most the `base` plugin")

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestCoverageAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestCoverageAggregationPlugin.kt
@@ -2,9 +2,9 @@ package io.github.gmazzo.android.test.aggregation
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.attributes.TestSuiteType
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.reporting.ReportingExtension
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.kotlin.dsl.apply
@@ -20,6 +20,7 @@ import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 class TestCoverageAggregationPlugin : Plugin<Project> {
 
     override fun apply(target: Project): Unit = with(target) {
+        ensureMinGradleVersion()
         ensureItsNotJava()
 
         apply(plugin = "reporting-base")
@@ -31,7 +32,7 @@ class TestCoverageAggregationPlugin : Plugin<Project> {
 
         val jacocoReport =
             the<ReportingExtension>().reports.create<JacocoCoverageReport>("jacocoAggregatedReport") {
-                testType.set(TestSuiteType.UNIT_TEST)
+                testSuiteName.set(SourceSet.TEST_SOURCE_SET_NAME)
                 reportTask.configure {
                     executionData.setFrom(files(*executionData.from.toTypedArray()).asFileTree)
                     classDirectories.setFrom(files(*classDirectories.from.toTypedArray()).asFileTree.matching(coverageExtension))

--- a/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestResultsAggregationPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/android/test/aggregation/TestResultsAggregationPlugin.kt
@@ -2,8 +2,8 @@ package io.github.gmazzo.android.test.aggregation
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.attributes.TestSuiteType
 import org.gradle.api.reporting.ReportingExtension
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.testing.AggregateTestReport
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
@@ -15,6 +15,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 class TestResultsAggregationPlugin : Plugin<Project> {
 
     override fun apply(target: Project): Unit = with(target) {
+        ensureMinGradleVersion()
         ensureItsNotJava()
 
         apply(plugin = "reporting-base")
@@ -24,7 +25,7 @@ class TestResultsAggregationPlugin : Plugin<Project> {
 
         val testResultsReport =
             the<ReportingExtension>().reports.create<AggregateTestReport>("testAggregatedReport") {
-                testType.set(TestSuiteType.UNIT_TEST)
+                testSuiteName.set(SourceSet.TEST_SOURCE_SET_NAME)
             }
 
         val testReportAggregation by configurations


### PR DESCRIPTION
Fixes compatibility with Gradle `8.13` introduced by https://github.com/gradle/gradle/pull/31706, where `TestSuiteType` was dropped in favor of `TestSuiteName`.

Since this is an `@Incubating` API, no backward compatibility efforts will be made.